### PR TITLE
fix ch_switch_notification startup processing

### DIFF
--- a/core/rtw_ap.c
+++ b/core/rtw_ap.c
@@ -1797,7 +1797,8 @@ chbw_decision:
 				, pdvobj->padapters[i]->mlmeextpriv.cur_channel
 				, pdvobj->padapters[i]->mlmeextpriv.cur_bwmode
 				, pdvobj->padapters[i]->mlmeextpriv.cur_ch_offset
-				, ht_option);
+				, ht_option
+				, 0);
 		}
 	}
 #endif /* defined(CONFIG_IOCTL_CFG80211) && (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0)) */

--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -16090,7 +16090,8 @@ void rtw_join_done_chk_ch(_adapter *adapter, int join_res)
 
 						rtw_cfg80211_ch_switch_notify(iface
 							, mlmeext->cur_channel, mlmeext->cur_bwmode, mlmeext->cur_ch_offset
-							, ht_option);
+							, ht_option
+							, 0);
 						#endif
 					}
 				}
@@ -16308,7 +16309,7 @@ exit:
 				the bss freq is updated by channel switch event.
 			*/
 			rtw_cfg80211_ch_switch_notify(adapter,
-				cur_ch, cur_bw, cur_ch_offset, ht_option);
+				cur_ch, cur_bw, cur_ch_offset, ht_option, 1);
 		}
 #endif
 	}

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -424,7 +424,8 @@ bool rtw_cfg80211_allow_ch_switch_notify(_adapter *adapter)
 	return 1;
 }
 
-u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset, u8 ht)
+u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset,
+	u8 ht, bool started)
 {
 	struct wiphy *wiphy = adapter_to_wiphy(adapter);
 	u8 ret = _SUCCESS;
@@ -438,6 +439,17 @@ u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset, u8 
 	ret = rtw_chbw_to_cfg80211_chan_def(wiphy, &chdef, ch, bw, offset, ht);
 	if (ret != _SUCCESS)
 		goto exit;
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0))
+	if (started) {
+		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0))
+		, 0
+#endif
+		);
+		goto exit;
+	}
+#endif
 
 	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef);
 

--- a/os_dep/linux/ioctl_cfg80211.h
+++ b/os_dep/linux/ioctl_cfg80211.h
@@ -412,7 +412,7 @@ void rtw_cfg80211_deinit_rfkill(struct wiphy *wiphy);
 #endif
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0))
-u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset, u8 ht);
+u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset, u8 ht, bool started);
 #endif
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 26)) && (LINUX_VERSION_CODE < KERNEL_VERSION(4, 7, 0))


### PR DESCRIPTION
On some platforms, the initialization process of this driver may kernel trap one or more times (e.g., refer to my PR from last year for the aircrack-ng version: [https://github.com/aircrack-ng/rtl8812au/pull/704](https://github.com/aircrack-ng/rtl8812au/pull/704)).

These changes are essentially a forward-port of associated previous changes present in the v5.6.4.2 rtl8812au Realtek driver (and others as well).  They appear to correct these startup problems in the driver initialization process.

Note that I also adapted the change so it works on kernel v5.11 as well.  I've been running this driver on both arm64 v5.10 and v5.11 for several weeks and it works great.  Many thanks for your work in providing this newer version of the Realtek driver!