### PR TITLE
modifications for kernel v5.12

### DIFF
--- a/os_dep/linux/recv_linux.c
+++ b/os_dep/linux/recv_linux.c
@@ -355,8 +355,13 @@ static int napi_recv(_adapter *padapter, int budget)
 
 #ifdef CONFIG_RTW_GRO
 		if (pregistrypriv->en_gro) {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 12, 0))
 			if (rtw_napi_gro_receive(&padapter->napi, pskb) != GRO_DROP)
 				rx_ok = _TRUE;
+#else
+			rtw_napi_gro_receive(&padapter->napi, pskb);
+			rx_ok = _TRUE;
+#endif
 			goto next;
 		}
 #endif /* CONFIG_RTW_GRO */


### PR DESCRIPTION
As of kernel v5.12, support for GRO_DROP has been removed (e.g., see https://www.spinics.net/lists/netdev/msg712091.html).  This change updates the 8821au driver so that it is compatible with the upstream changes in the new v5.12 kernel.
